### PR TITLE
added a flag to include optional deps when generating/updating manifest and notices

### DIFF
--- a/packages/newrelic-plugin-oss-third-party/README.md
+++ b/packages/newrelic-plugin-oss-third-party/README.md
@@ -45,11 +45,12 @@ ARGUMENTS
 
 OPTIONS
   --forceUpdate  Force update of manifest file.
+  --includeOptDeps Include optional dependencies in manifest.
 
 DESCRIPTION
   (1) Make sure you have run "npm install" before using this tool. It depends on node_modules.
   (2) Run with "manifest" to update the manifest file (third_party_manifest.json).
-  (3) Review the contents of third_party_manifest.json for accuracy and items marked "FOR_REVIEW" that require manual 
+  (3) Review the contents of third_party_manifest.json for accuracy and items marked "FOR_REVIEW" that require manual
   intervention.
   (4) Run with "notices" to update the notices file (THIRD_PARTY_NOTICES.md) using the manifest.
   (5) Review the contents of THIRD_PARTY_NOTICES.md for accuracy.
@@ -64,7 +65,7 @@ _See code: [src/commands/third-party.js](https://github.com/newrelic/newrelic-os
 ## Additional Third-Party Notices
 If you have additional third party notices which you would like to include, you can place them in a `THIRD_PARTY_NOTICES_ADDENDUM.md` file at the root of the project. To ensure the table of contents is formatted correctly, use the following format for this file:
 ```Markdown
-You can insert a disclaimer about this file here 
+You can insert a disclaimer about this file here
 
 <!-- licence -->
 ## Package/Licence name

--- a/packages/newrelic-plugin-oss-third-party/src/commands/third-party.js
+++ b/packages/newrelic-plugin-oss-third-party/src/commands/third-party.js
@@ -18,10 +18,10 @@ const THIRD_PARTY_ADDENDUM_FILE = 'THIRD_PARTY_NOTICES_ADDENDUM.md'
 
 class ThirdPartyCommand extends Command {
   async run() {
-    const {args: {file}, flags: {forceUpdate}} = this.parse(ThirdPartyCommand)
+    const {args: {file}, flags: {forceUpdate, includeOptDeps }} = this.parse(ThirdPartyCommand)
 
     if (!fs.existsSync(THIRD_PARTY_MANIFEST_FILE)) {
-      await this.initializeManifest()
+      await this.initializeManifest(includeOptDeps)
     }
 
     const responsibilityNotice = 'This tool assists with the creation of third party notice files, but it cannot guarantee correctness for all use cases. You are responsible for validating the output and manually correcting any issues.'
@@ -30,13 +30,13 @@ class ThirdPartyCommand extends Command {
     this.log(chalk.red(`${responsibilityNotice}\n\n${allowedLicensesNotice}\n`))
 
     if (file === 'manifest') {
-      await this.updateManifest(forceUpdate)
+      await this.updateManifest(forceUpdate, includeOptDeps)
     } else if (file === 'notices') {
       await this.updateNotices()
     }
   }
 
-  async initializeManifest() {
+  async initializeManifest(includeOptDeps) {
     this.log(chalk.red(`You are missing ${THIRD_PARTY_MANIFEST_FILE} to ` +
         'configure your project. Let\'s set it up!'))
     const projectName = await cli.prompt('What is the user-friendly name of your project (used to reference your project in output)?')
@@ -47,6 +47,7 @@ class ThirdPartyCommand extends Command {
       projectName: projectName,
       projectUrl: projectUrl,
       includeDev: true,
+      includeOptDeps
     }
 
     fs.writeJsonSync(THIRD_PARTY_MANIFEST_FILE, baseConfig, {
@@ -54,7 +55,7 @@ class ThirdPartyCommand extends Command {
     })
   }
 
-  async updateManifest(forceUpdate) {
+  async updateManifest(forceUpdate, includeOptDeps) {
     this.log(chalk.inverse(` Updating ${THIRD_PARTY_MANIFEST_FILE}. `))
 
     const manifest = await this.getManifest() || {}
@@ -62,11 +63,14 @@ class ThirdPartyCommand extends Command {
       lastUpdated, includeDev, dependencies, devDependencies, ...otherConfig
     } = manifest
 
+    manifest.includeOptDeps = includeOptDeps
+
     const updatedDependencies = await this.getUpdatedDependencies(manifest, forceUpdate)
     const updatedManifest = {
       lastUpdated: `${new Date()}`,
       ...otherConfig,
       includeDev,
+      includeOptDeps,
       ...updatedDependencies,
     }
 
@@ -349,6 +353,10 @@ ${licenseContent}
     if (manifest.includeDev) {
       depFieldsToInclude.push('devDependencies')
     }
+
+    if (manifest.includeOptDeps) {
+      depFieldsToInclude.push('optionalDependencies')
+    }
     return depFieldsToInclude
   }
 
@@ -446,6 +454,10 @@ ThirdPartyCommand.args = [{
 ThirdPartyCommand.flags = {
   forceUpdate: flags.boolean({
     description: 'Force update of manifest file.',
+    default: false,
+  }),
+  includeOptDeps: flags.boolean({
+    description: 'Include optional dependencies in manfiest',
     default: false,
   }),
 }


### PR DESCRIPTION
This PR fixes #13.  It includes a new flag `--includeOptDeps` to add optional dependencies to both manfiest and notices.  

To test execute the following from this branch on a code base:

```sh
node path/to/newrelic-oss-cli/packages/newrelic-oss-cli/bin/run third-party manifest --forceUpdate --includeOptDeps
node path/to/newrelic-oss-cli/packages/newrelic-oss-cli/bin/run third-party notices --forceUpdate --includeOptDeps
```